### PR TITLE
Add -path option for injector (#2)

### DIFF
--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -60,13 +60,14 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
-	LPVOID pBuffer;                                  // ¹²ÏúàÚ´æÖ¸ÕE
+	string strMapName("ShareMemory");                // Memory mapped object name
+	LPVOID pBuffer;                                  // Shared memory pointer
+
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
+	// Failed to open, create it
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏúàÚ´æµÄÖ¸ÕE¬ÉèÖÃÀEæµÄÊı¾İ
+	// Map a view of the object, get the pointer to the shared memory, and set the data inside
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "Ğ´ÈE²ÏúàÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
+	//cout << "Write shared memory data: " << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -1,4 +1,4 @@
-ï»¿#pragma once
+#pragma once
 #define _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNING
 
@@ -60,14 +60,13 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // å†…å­˜æ˜ å°„å¯¹è±¡åç§°
-	LPVOID pBuffer;                                  // å…±äº«å†…å­˜æŒ‡é’ˆ
-
+	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
+	LPVOID pBuffer;                                  // ¹²ÏúàÚ´æÖ¸ÕE
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// æ‰“å¼€å¤±è´¥ï¼Œåˆ›å»ºä¹‹
+	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// æ˜ å°„å¯¹è±¡çš„ä¸€ä¸ªè§†å›¾ï¼Œå¾—åˆ°æŒ‡å‘å…±äº«å†…å­˜çš„æŒ‡é’ˆï¼Œè®¾ç½®é‡Œé¢çš„æ•°æ®
+	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏúàÚ´æµÄÖ¸ÕE¬ÉèÖÃÀEæµÄÊı¾İ
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "å†™å…¥å…±äº«å†…å­˜æ•°æ®ï¼š" << (char *)pBuffer << endl;
+	//cout << "Ğ´ÈE²ÏúàÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #define _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNING
 
@@ -23,13 +23,14 @@ static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPAR
 	return 0;
 }
 
-string BrowseFolder()
+string BrowseFolder(const char* initialPath)
 {
 	TCHAR path[MAX_PATH];
 
 	BROWSEINFO bi = { 0 };
 	bi.lpszTitle = ("Browse for save folder...");
 	bi.ulFlags = BIF_RETURNONLYFSDIRS | BIF_NEWDIALOGSTYLE;
+	bi.lParam = (LPARAM)initialPath;
 	bi.lpfn = BrowseCallbackProc;
 
 	LPITEMIDLIST pidl = SHBrowseForFolder(&bi);
@@ -59,14 +60,14 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
-	LPVOID pBuffer;                                  // ¹²ÏíÄÚ´æÖ¸Õë
+	string strMapName("ShareMemory");                // å†…å­˜æ˜ å°„å¯¹è±¡åç§°
+	LPVOID pBuffer;                                  // å…±äº«å†…å­˜æŒ‡é’ˆ
 
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
+	// æ‰“å¼€å¤±è´¥ï¼Œåˆ›å»ºä¹‹
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏíÄÚ´æµÄÖ¸Õë£¬ÉèÖÃÀïÃæµÄÊı¾İ
+	// æ˜ å°„å¯¹è±¡çš„ä¸€ä¸ªè§†å›¾ï¼Œå¾—åˆ°æŒ‡å‘å…±äº«å†…å­˜çš„æŒ‡é’ˆï¼Œè®¾ç½®é‡Œé¢çš„æ•°æ®
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "Ğ´Èë¹²ÏíÄÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
+	//cout << "å†™å…¥å…±äº«å†…å­˜æ•°æ®ï¼š" << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/main.cpp
+++ b/Dll_Injector/main.cpp
@@ -6,13 +6,13 @@
 #define PROCESS_NAME "melonbooksviewer.exe"
 #define DLL_NAME "MelonDumper.dll"
 
-// usage: Dll_Injector.exe [-path <initial path to save image file>]
+// usage: Dll_Injector.exe [--path <initial path to save image file>]
 int main(int argc, const char *argv[])
 {
 	const char* initialPath = "";
 	for (int index = 1; index < argc; ++index)
 	{
-		if (strcmp(argv[index], "-path") == 0 && index + 1 < argc)
+		if (strcmp(argv[index], "--path") == 0 && index + 1 < argc)
 		{
 			++index;
 			initialPath = argv[index];

--- a/Dll_Injector/main.cpp
+++ b/Dll_Injector/main.cpp
@@ -6,9 +6,19 @@
 #define PROCESS_NAME "melonbooksviewer.exe"
 #define DLL_NAME "MelonDumper.dll"
 
+// usage: Dll_Injector.exe [-path <initial path to save image file>]
 int main(int argc, const char *argv[])
 {
-	std::string path = BrowseFolder();
+	const char* initialPath = "";
+	for (int index = 1; index < argc; ++index)
+	{
+		if (strcmp(argv[index], "-path") == 0 && index + 1 < argc)
+		{
+			++index;
+			initialPath = argv[index];
+		}
+	}
+	std::string path = BrowseFolder(initialPath);
 	if (path == "")return EXIT_SUCCESS;
 	set_global_path(path);
 


### PR DESCRIPTION
This is a proposed fix for issue #2.

By specifying `-path <initial directory path name>` as a command argument for `Dll_Injector.exe`, you can change the initial value of the directory where images are saved.
The `-path` command argument is optional.

By the way, the code page of the original `common.h` was not UNICODE, and it contained comments in simplified Chinese.
When I edited `common.h`, there was a possibility of garbled characters, so I changed the code page to UTF8 with BOM.
note that.