### PR TITLE
Issue #4 (Revised pull request)

### DIFF
--- a/Dll_Injector/Dll_Injector.vcxproj
+++ b/Dll_Injector/Dll_Injector.vcxproj
@@ -158,6 +158,7 @@
   <ItemGroup>
     <ClInclude Include="common.h" />
     <ClInclude Include="injector.h" />
+    <ClInclude Include="interprocess.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/Dll_Injector/Dll_Injector.vcxproj.filters
+++ b/Dll_Injector/Dll_Injector.vcxproj.filters
@@ -29,5 +29,8 @@
     <ClInclude Include="common.h">
       <Filter>头文件</Filter>
     </ClInclude>
+    <ClInclude Include="interprocess.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -1,4 +1,4 @@
-ï»¿#pragma once
+#pragma once
 #define _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNING
 
@@ -8,7 +8,6 @@
 #include <shlobj.h>
 #include <iostream>
 #include <sstream>
-#include "interprocess.h"
 
 using namespace std;
 
@@ -60,14 +59,13 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // ï¾„ï¾šï½´è´Šï½³ï¾‰è¼ï¾”ï¾îŠ¶ï¨¤ï¾†
-	LPVOID pBuffer;                                  // ï½¹ï½²ï¾ï¤©ï¾šï½´è´ï½¸ï¾•ãƒ»
-
+	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
+	LPVOID pBuffer;                                  // ¹²ÏúàÚ´æÖ¸ÕE
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// æ‰“å¼€å¤±è´¥ï¼Œåˆ›å»ºä¹‹
+	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// æ˜ å°„å¯¹è±¡çš„ä¸€ä¸ªè§†å›¾ï¼Œå¾—åˆ°æŒ‡å‘å…±äº«å†…å­˜çš„æŒ‡é’ˆï¼Œè®¾ç½®é‡Œé¢çš„æ•°æ®
+	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏúàÚ´æµÄÖ¸ÕE¬ÉèÖÃÀEæµÄÊı¾İ
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "å†™å…¥å…±äº«å†…å­˜æ•°æ®ï¼š" << (char *)pBuffer << endl;
+	//cout << "Ğ´ÈE²ÏúàÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -1,4 +1,4 @@
-#pragma once
+ï»¿#pragma once
 #define _CRT_SECURE_NO_DEPRECATE
 #define _CRT_SECURE_NO_WARNING
 
@@ -8,6 +8,7 @@
 #include <shlobj.h>
 #include <iostream>
 #include <sstream>
+#include "interprocess.h"
 
 using namespace std;
 
@@ -59,14 +60,14 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
-	LPVOID pBuffer;                                  // ¹²ÏíÄÚ´æÖ¸Õë
+	string strMapName("ShareMemory");                // ï¾„ï¾šï½´è´Šï½³ï¾‰è¼ï¾”ï¾îŠ¶ï¨¤ï¾†
+	LPVOID pBuffer;                                  // ï½¹ï½²ï¾ï¤©ï¾šï½´è´ï½¸ï¾•ãƒ»
 
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
+	// æ‰“å¼€å¤±è´¥ï¼Œåˆ›å»ºä¹‹
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏíÄÚ´æµÄÖ¸Õë£¬ÉèÖÃÀïÃæµÄÊı¾İ
+	// æ˜ å°„å¯¹è±¡çš„ä¸€ä¸ªè§†å›¾ï¼Œå¾—åˆ°æŒ‡å‘å…±äº«å†…å­˜çš„æŒ‡é’ˆï¼Œè®¾ç½®é‡Œé¢çš„æ•°æ®
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "Ğ´Èë¹²ÏíÄÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
+	//cout << "å†™å…¥å…±äº«å†…å­˜æ•°æ®ï¼š" << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/common.h
+++ b/Dll_Injector/common.h
@@ -59,13 +59,14 @@ string CurrentPath() {
 }
 
 void set_global_path(string path) {
-	string strMapName("ShareMemory");                // ÄÚ´æÓ³Éä¶ÔÏóÃû³Æ
-	LPVOID pBuffer;                                  // ¹²ÏúàÚ´æÖ¸ÕE
+	string strMapName("ShareMemory");                // Memory mapped object name
+	LPVOID pBuffer;                                  // Shared memory pointer
+
 	HANDLE hMap = ::OpenFileMapping(FILE_MAP_ALL_ACCESS, 0, strMapName.c_str());
-	// ´ò¿ªÊ§°Ü£¬´´½¨Ö®
+	// Failed to open, create it
 	hMap = ::CreateFileMapping(INVALID_HANDLE_VALUE,NULL,PAGE_READWRITE,0, path.length() + 1,strMapName.c_str());
-	// Ó³Éä¶ÔÏóµÄÒ»¸öÊÓÍ¼£¬µÃµ½Ö¸Ïò¹²ÏúàÚ´æµÄÖ¸ÕE¬ÉèÖÃÀEæµÄÊı¾İ
+	// Map a view of the object, get the pointer to the shared memory, and set the data inside
 	pBuffer = ::MapViewOfFile(hMap, FILE_MAP_ALL_ACCESS, 0, 0, 0);
 	strcpy((char*)pBuffer, path.c_str());
-	//cout << "Ğ´ÈE²ÏúàÚ´æÊı¾İ£º" << (char *)pBuffer << endl;
+	//cout << "Write shared memory data: " << (char *)pBuffer << endl;
 }

--- a/Dll_Injector/injector.cpp
+++ b/Dll_Injector/injector.cpp
@@ -1,4 +1,5 @@
 #include"injector.h"
+#include "interprocess.h"
 
 //-----------------------------------------------------------
 // Get Process ID by its name
@@ -30,7 +31,7 @@ int getProcID(const string& p_name)
 //-----------------------------------------------------------
 // Inject DLL to target process
 //-----------------------------------------------------------
-bool InjectDLL(const int &pid, const string &DLL_Path)
+bool InjectDLL(const int &pid, const string &DLL_Path, HANDLE InjectionCompletionEventHandle)
 {
 	long dll_size = DLL_Path.length() + 1;
 	HANDLE hProc = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
@@ -69,6 +70,7 @@ bool InjectDLL(const int &pid, const string &DLL_Path)
 
 	if ((hProc != NULL) && (MyAlloc != NULL) && (IsWriteOK != ERROR_INVALID_HANDLE) && (ThreadReturn != NULL))
 	{
+		WaitForSingleObject(InjectionCompletionEventHandle, INFINITE);
 		cout << "[+]DLL Successfully Injected :)" << endl;
 		return true;
 	}

--- a/Dll_Injector/injector.h
+++ b/Dll_Injector/injector.h
@@ -11,4 +11,4 @@ using namespace std;
 
 
 int getProcID(const string& p_name);
-bool InjectDLL(const int &pid, const string &DLL_Path);
+bool InjectDLL(const int &pid, const string &DLL_Path, HANDLE InjectionCompletionEventHandle);

--- a/Dll_Injector/interprocess.h
+++ b/Dll_Injector/interprocess.h
@@ -1,0 +1,7 @@
+#pragma once
+
+// Use GUID as the object name to minimize the possibility of name conflicts with other applications.
+//#define	SHARED_MEMORY_OBJECT_NAME		("MelonBooksDumper_{670CD378-F245-4A89-B854-F56EE6AD548D}")
+#define	INJECTION_COMPLETION_EVENT_NAME	("MelonBooksDumper_{9CD1B199-A89B-4B61-9DD8-B967F3D18AA6}")
+
+// END OF FILE

--- a/Dll_Injector/main.cpp
+++ b/Dll_Injector/main.cpp
@@ -6,14 +6,19 @@
 #define PROCESS_NAME "melonbooksviewer.exe"
 #define DLL_NAME "MelonDumper.dll"
 
+HANDLE InjectionCompletionEventHandle;
+
 int main(int argc, const char *argv[])
 {
+	InjectionCompletionEventHandle = ::CreateEvent(NULL, TRUE, FALSE, INJECTION_COMPLETION_EVENT_NAME);
+	if (InjectionCompletionEventHandle == NULL)
+		return EXIT_FAILURE;
 	std::string path = BrowseFolder();
 	if (path == "")return EXIT_SUCCESS;
 	set_global_path(path);
 
-	InjectDLL(getProcID(PROCESS_NAME), CurrentPath()+"\\"+DLL_NAME);
-	Sleep(1000);
+	InjectDLL(getProcID(PROCESS_NAME), CurrentPath() + "\\" + DLL_NAME, InjectionCompletionEventHandle);
+
 	std::cout << "Exiting..." << endl;
 	return EXIT_SUCCESS;
 }

--- a/Dll_Injector/main.cpp
+++ b/Dll_Injector/main.cpp
@@ -2,6 +2,7 @@
 #include"injector.h"
 #include <stdlib.h>
 #include <iostream>
+#include "interprocess.h"
 
 #define PROCESS_NAME "melonbooksviewer.exe"
 #define DLL_NAME "MelonDumper.dll"

--- a/MelonDumper/MelonDumper.vcxproj
+++ b/MelonDumper/MelonDumper.vcxproj
@@ -157,6 +157,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="..\Dll_Injector\interprocess.h" />
     <ClInclude Include="detours.h" />
     <ClInclude Include="detver.h" />
     <ClInclude Include="framework.h" />

--- a/MelonDumper/MelonDumper.vcxproj.filters
+++ b/MelonDumper/MelonDumper.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClInclude Include="detver.h">
       <Filter>头文件</Filter>
     </ClInclude>
+    <ClInclude Include="..\Dll_Injector\interprocess.h">
+      <Filter>头文件</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp">

--- a/MelonDumper/dllmain.cpp
+++ b/MelonDumper/dllmain.cpp
@@ -8,6 +8,7 @@
 #include <Psapi.h> // To get process info
 #include <process.h>
 #include <stdlib.h>
+#include "../Dll_Injector/interprocess.h"
 
 #define AttachRVA_v110 0x205AF
 #define AttachRVA_v120 0x23FDF
@@ -144,11 +145,15 @@ BOOL APIENTRY DllMain( HMODULE hModule,
                        LPVOID lpReserved
                      )
 {
-    switch (ul_reason_for_call)
+	HANDLE InjectionCompletionEventHandle = NULL;
+	switch (ul_reason_for_call)
     {
     case DLL_PROCESS_ATTACH:
+		InjectionCompletionEventHandle = ::OpenEvent(EVENT_MODIFY_STATE, FALSE, INJECTION_COMPLETION_EVENT_NAME);
 		Init();
 		Attach();
+		SetEvent(InjectionCompletionEventHandle);
+		break;
     case DLL_THREAD_ATTACH:
     case DLL_THREAD_DETACH:
     case DLL_PROCESS_DETACH:


### PR DESCRIPTION
This is a proposed fix for issue #4
This fix makes use of named event objects.
Please refer to it if you like.

The main corrections are as follows.

- Added code to create a named event object before injection in `Dll_Injector.exe`.
- Fixed `Dll_Injector.exe` to wait for a named event object instead of waiting for 1000 milliseconds after starting injection.
- Fixed `MelonDumper.dll` to set a named event object at the end of injection.
- Since `Dll_Injector.exe` and `MelonDumper.dll` handle common named event objects, an include file interprocess.h was added that defines the name of the event object.

# [Supplement]
There are no code changes in `common.h`.

However, in my development environment (Visual Studio 2022), `common.h` becomes garbled just by editing other files, so when I push it to github, `common.h` is also recognized as having been modified.

The cause of the garbled characters is probably related to the fact that the original code page of `common.h` is EUC (Simplified Chinese).

Fortunately, the only parts that were garbled seemed to be comments and debug messages, so I changed the code page of `common.h` to UTF-8 and translated the garbled parts to English.